### PR TITLE
71:  Update HL7 service to new infrastructure

### DIFF
--- a/ingest/hl7/com.ibm.streamsx.health.hapi/.classpath
+++ b/ingest/hl7/com.ibm.streamsx.health.hapi/.classpath
@@ -20,5 +20,6 @@
 	<classpathentry kind="lib" path="release/opt/lib/log4j-1.2.17.jar"/>
 	<classpathentry kind="lib" path="release/opt/lib/slf4j-api-1.6.6.jar"/>
 	<classpathentry kind="lib" path="release/opt/lib/slf4j-log4j12-1.6.6.jar"/>
+	<classpathentry kind="lib" path="release/opt/lib/gson-1.7.2.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/ingest/hl7/com.ibm.streamsx.health.hapi/build.gradle
+++ b/ingest/hl7/com.ibm.streamsx.health.hapi/build.gradle
@@ -55,6 +55,10 @@ dependencies {
 	// https://mvnrepository.com/artifact/log4j/log4j
 	compile group: 'log4j', name: 'log4j', version: '1.2.17'
 	
+	// https://mvnrepository.com/artifact/com.google.code.gson/gson
+	compile group: 'com.google.code.gson', name: 'gson', version: '1.7.2'
+	
+	
 	compile name: 'com.ibm.streams.operator'
 	compile name: 'com.ibm.streams.operator.samples'
 	compile name: 'com.ibm.streamsx.topology'

--- a/ingest/hl7/com.ibm.streamsx.health.hapi/src/main/java/com/ibm/streamsx/health/hapi/services/AbstractHL7Service.java
+++ b/ingest/hl7/com.ibm.streamsx.health.hapi/src/main/java/com/ibm/streamsx/health/hapi/services/AbstractHL7Service.java
@@ -28,18 +28,19 @@ abstract public class AbstractHL7Service implements Serializable{
 	
 
 	protected void addDependencies(Topology topology) {
-		topology.addJarDependency("opt/lib/hapi-base-2.2.jar");
-		topology.addJarDependency("opt/lib/hapi-structures-v21-2.2.jar");
-		topology.addJarDependency("opt/lib/hapi-structures-v22-2.2.jar");
-		topology.addJarDependency("opt/lib/hapi-structures-v23-2.2.jar");
-		topology.addJarDependency("opt/lib/hapi-structures-v231-2.2.jar");
-		topology.addJarDependency("opt/lib/hapi-structures-v24-2.2.jar");
-		topology.addJarDependency("opt/lib/hapi-structures-v25-2.2.jar");
-		topology.addJarDependency("opt/lib/hapi-structures-v251-2.2.jar");
-		topology.addJarDependency("opt/lib/hapi-structures-v26-2.2.jar");
-		topology.addJarDependency("opt/lib/log4j-1.2.17.jar");
-		topology.addJarDependency("opt/lib/slf4j-api-1.6.6.jar");
-		topology.addJarDependency("opt/lib/slf4j-log4j12-1.6.6.jar");
+		topology.addJarDependency("release/opt/lib/hapi-base-2.2.jar");
+		topology.addJarDependency("release/opt/lib/hapi-structures-v21-2.2.jar");
+		topology.addJarDependency("release/opt/lib/hapi-structures-v22-2.2.jar");
+		topology.addJarDependency("release/opt/lib/hapi-structures-v23-2.2.jar");
+		topology.addJarDependency("release/opt/lib/hapi-structures-v231-2.2.jar");
+		topology.addJarDependency("release/opt/lib/hapi-structures-v24-2.2.jar");
+		topology.addJarDependency("release/opt/lib/hapi-structures-v25-2.2.jar");
+		topology.addJarDependency("release/opt/lib/hapi-structures-v251-2.2.jar");
+		topology.addJarDependency("release/opt/lib/hapi-structures-v26-2.2.jar");
+		topology.addJarDependency("release/opt/lib/log4j-1.2.17.jar");
+		topology.addJarDependency("release/opt/lib/slf4j-api-1.6.6.jar");
+		topology.addJarDependency("release/opt/lib/slf4j-log4j12-1.6.6.jar");
+		topology.addJarDependency("release/opt/lib/gson-1.7.2.jar");
 	}
 	
 	protected int getPort(){


### PR DESCRIPTION
* Add gson to classpath to work with latest topology build.  
* Fix where we pull jar files dependencies for the service.